### PR TITLE
Lazy connect + improve CI support

### DIFF
--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -10,10 +10,13 @@ var util = require('util');
 exports.initialize = function initializeDataSource(dataSource, callback) {
   var settings = dataSource.settings;
 
-  // TODO handle settings.lazyConnect - use ioredis option "lazyConnect"
-  dataSource.connector = new RedisKeyValueConnector(settings);
+  dataSource.connector = new RedisKeyValueConnector(settings, dataSource);
 
   if (!callback) return;
+
+  if (settings.lazyConnect) {
+    return process.nextTick(callback);
+  }
 
   dataSource.connector._client
     .once('connect', function() { callback(); })
@@ -54,4 +57,8 @@ RedisKeyValueConnector.prototype.execute = function(command, args, cb) {
     cb(err, result);
   });
   this._client.sendCommand(cmd);
+};
+
+RedisKeyValueConnector.prototype.disconnect = function(cb) {
+  this._client.quit(cb);
 };

--- a/test/helpers/data-source-factory.js
+++ b/test/helpers/data-source-factory.js
@@ -5,14 +5,18 @@ var connector = require('../..');
 var extend = require('util')._extend;
 
 var SETTINGS = {
-  // FIXME when running on IBM JenkinsCI:
-  // - use REDIS_HOST and REDIS_PORT,
-  // - use unique DB number (PID % 16)
-  host: 'localhost',
+  host: process.env.REDIS_HOST || 'localhost',
+  port: process.env.REDIS_PORT || undefined,
   connector: connector,
   // produce nicer stack traces
   showFriendlyErrorStack: true,
 };
+
+if (process.env.CI) {
+  // Try to avoid collisions when multiple CI jobs are running on the same host
+  // by picking a (semi)random database number to use.
+  SETTINGS.db = process.pid % 16;
+}
 
 function createDataSource(options) {
   var settings = extend({}, SETTINGS);

--- a/test/helpers/data-source-factory.js
+++ b/test/helpers/data-source-factory.js
@@ -2,20 +2,46 @@
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
 var connector = require('../..');
+var extend = require('util')._extend;
 
 var SETTINGS = {
   // FIXME when running on IBM JenkinsCI:
   // - use REDIS_HOST and REDIS_PORT,
   // - use unique DB number (PID % 16)
-  url: 'redis://localhost',
+  host: 'localhost',
   connector: connector,
+  // produce nicer stack traces
+  showFriendlyErrorStack: true,
 };
 
-function createDataSource() {
-  return new DataSource(SETTINGS);
+function createDataSource(options) {
+  var settings = extend({}, SETTINGS);
+  settings = extend(settings, options);
+
+  return new DataSource(settings);
 };
+
 module.exports = createDataSource;
 
+var invalidPort = 4; // invalid port where nobody is listening
+
+createDataSource.failing = function(options) {
+  var settings = extend({
+    host: '127.0.0.1',
+    port: invalidPort++,
+
+    // disable auto-reconnect
+    retryStrategy: null,
+    reconnectOnError: null,
+  }, options);
+
+  return createDataSource(settings);
+};
+
 beforeEach(function clearDatabase(done) {
-  createDataSource().connector.execute('FLUSHDB', done);
+  var ds = createDataSource();
+  ds.connector.execute('FLUSHDB', function(err) {
+    if (err) return done(err);
+    ds.disconnect(done);
+  });
 });

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var createDataSource = require('../helpers/data-source-factory');
+var expect = require('../helpers/expect');
+
+describe('setup', function() {
+  it('reports connection errors by default', function(done) {
+    var ds = createDataSource.failing({lazyConnect: false});
+
+    ds.once('error', function(err) {
+      expect(err.message).to.contain('ECONNREFUSED');
+      ds.disconnect(done);
+    });
+  });
+
+  context('with lazyConnect:true', function() {
+    it('does not connect at setup time', function(done) {
+      var ds = createDataSource.failing({lazyConnect: true});
+
+      // Assume no connection was made if there is no error reported
+      // within reasonable time. The test passes in such case.
+      var errTimeout = setTimeout(function() { done(); }, 1000);
+
+      ds.once('error', function(err) {
+        clearTimeout(errTimeout);
+        done(err);
+      });
+    });
+
+    it('reports connection failure on the first command', function(done) {
+      var ds = createDataSource.failing({lazyConnect: true});
+      ds.ping(function(err) {
+        // NOTE(bajtos) This depends on the current behaviour of ioredis.
+        // Currently, ioredis does not surface the original connection error
+        // in lazy-connect mode.
+        expect(err.message).to.contain('Connection is closed.');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Implement `lazyConnect:true`
- Honour environment variables REDIS_HOST and REDIS_PORT.
- Try to avoid collisions when multiple CI jobs are running on the same host by picking a (semi)random database number to use.

Connect to strongloop/loopback#2530

/to @jannyHou @raymondfeng @superkhau please review