### PR TITLE
Implement KeyValueAccessObject API

### DIFF
--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -23,6 +23,8 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
     .once('error', callback);
 };
 
+exports._Connector = RedisKeyValueConnector;
+
 function RedisKeyValueConnector(settings, dataSource) {
   Connector.call(this, 'kv-redis', settings);
   this.dataSource = dataSource;
@@ -63,7 +65,7 @@ RedisKeyValueConnector.prototype.disconnect = function(cb) {
 
 RedisKeyValueConnector.prototype.set =
 function(modelName, key, value, options, callback) {
-  var composedKey = this._composeKey(modelName, key);
+  var composedKey = RedisKeyValueConnector._composeKey(modelName, key);
   var rawData = this._packer.encode(value).slice();
 
   var args = [composedKey, rawData];
@@ -77,7 +79,7 @@ function(modelName, key, value, options, callback) {
 
 RedisKeyValueConnector.prototype.get =
 function(modelName, key, options, callback) {
-  var composedKey = this._composeKey(modelName, key);
+  var composedKey = RedisKeyValueConnector._composeKey(modelName, key);
   var packer = this._packer;
   this.execute('GET', [composedKey], function(err, rawData) {
     if (err) return callback(err);
@@ -88,7 +90,7 @@ function(modelName, key, options, callback) {
 
 RedisKeyValueConnector.prototype.expire =
 function(modelName, key, ttl, options, callback) {
-  var composedKey = this._composeKey(modelName, key);
+  var composedKey = RedisKeyValueConnector._composeKey(modelName, key);
   this.execute('PEXPIRE', [composedKey, ttl], function(err, result) {
     if (err) return callback(err);
     if (!result) {
@@ -100,8 +102,8 @@ function(modelName, key, ttl, options, callback) {
   });
 };
 
-RedisKeyValueConnector.prototype._composeKey = function(modelName, key) {
+RedisKeyValueConnector._composeKey = function(modelName, key) {
   // FIXME escape values to prevent collision
   //  'model' + 'foo:bar' vs 'model:foo' + 'bar'
-  return modelName + ':' + key;
+  return encodeURIComponent(modelName) + ':' + key;
 };

--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -3,8 +3,8 @@
 var assert = require('assert');
 var Connector = require('loopback-connector').Connector;
 var debug = require('debug')('loopback:connector:kv-redis');
+var createPacker = require('./packer');
 var Redis = require('ioredis');
-var Command = Redis.Command;
 var util = require('util');
 
 exports.initialize = function initializeDataSource(dataSource, callback) {
@@ -30,10 +30,8 @@ function RedisKeyValueConnector(settings, dataSource) {
   debug('Connector settings', settings);
 
   this._client = new Redis(settings.url || settings);
-
-  this.DataAccessObject = function() {
-    // FIXME use KV DAO from juggler instead
-  };
+  this._packer = createPacker();
+  this.DataAccessObject = dataSource.juggler.KeyValueAccessObject;
 };
 
 util.inherits(RedisKeyValueConnector, Connector);
@@ -52,7 +50,7 @@ RedisKeyValueConnector.prototype.execute = function(command, args, cb) {
   assert(typeof cb === 'function', 'callback must be a function');
 
   debug('EXECUTE %j %j', command, args);
-  var cmd = new Command(command, args, 'utf8', function(err, result) {
+  var cmd = new Redis.Command(command, args, 'utf8', function(err, result) {
     debug('RESULT OF %j -- %j', command, result);
     cb(err, result);
   });
@@ -61,4 +59,49 @@ RedisKeyValueConnector.prototype.execute = function(command, args, cb) {
 
 RedisKeyValueConnector.prototype.disconnect = function(cb) {
   this._client.quit(cb);
+};
+
+RedisKeyValueConnector.prototype.set =
+function(modelName, key, value, options, callback) {
+  var composedKey = this._composeKey(modelName, key);
+  var rawData = this._packer.encode(value).slice();
+
+  var args = [composedKey, rawData];
+  if (options.ttl) {
+    args.push('PX');
+    args.push(options.ttl);
+  }
+
+  this.execute('SET', args, callback);
+};
+
+RedisKeyValueConnector.prototype.get =
+function(modelName, key, options, callback) {
+  var composedKey = this._composeKey(modelName, key);
+  var packer = this._packer;
+  this.execute('GET', [composedKey], function(err, rawData) {
+    if (err) return callback(err);
+    var value = rawData !== null ? packer.decode(rawData) : null;
+    callback(null, value);
+  });
+};
+
+RedisKeyValueConnector.prototype.expire =
+function(modelName, key, ttl, options, callback) {
+  var composedKey = this._composeKey(modelName, key);
+  this.execute('PEXPIRE', [composedKey, ttl], function(err, result) {
+    if (err) return callback(err);
+    if (!result) {
+      return callback(new Error(
+        'Key does not exist or the timeout cannot be set. ' +
+        'Model: ' + modelName + ' Key: ' + key));
+    }
+    callback();
+  });
+};
+
+RedisKeyValueConnector.prototype._composeKey = function(modelName, key) {
+  // FIXME escape values to prevent collision
+  //  'model' + 'foo:bar' vs 'model:foo' + 'bar'
+  return modelName + ':' + key;
 };

--- a/lib/packer.js
+++ b/lib/packer.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var msgpack = require('msgpack5');
+
+module.exports = function createPacker() {
+  var packer = msgpack({forceFloat64: true});
+  packer.register(1, Date, encodeDate, decodeDate);
+  return packer;
+};
+
+function encodeDate(obj) {
+  return new Buffer(obj.toISOString(), 'utf8');
+}
+
+function decodeDate(buf) {
+  return new Date(buf.toString('utf8'));
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "debug": "^2.2.0",
     "ioredis": "^2.2.0",
-    "loopback-connector": "^2.4.0"
+    "loopback-connector": "^2.4.0",
+    "msgpack5": "^3.4.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -31,6 +32,7 @@
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
     "loopback-datasource-juggler": "^2.47.0",
-    "mocha": "^2.5.3"
+    "mocha": "^2.5.3",
+    "should": "^8.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "lib/kv-redis.js",
   "scripts": {
-    "test": "mocha test/integration/*.js",
+    "test": "mocha test/unit/*.js && mocha test/integration/*.js",
     "posttest": "npm run lint",
     "lint": "eslint ."
   },

--- a/test/integration/juggler-api.integration.js
+++ b/test/integration/juggler-api.integration.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var createDataSource = require('../helpers/data-source-factory');
+var expect = require('../helpers/expect');
+
+describe('Juggler API', function() {
+  require('loopback-datasource-juggler/test/kvao.suite.js')(createDataSource);
+});

--- a/test/unit/compose-key.unit.js
+++ b/test/unit/compose-key.unit.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var composeKey = require('../..')._Connector._composeKey;
+var expect = require('../helpers/expect');
+
+describe('RedisKeyValueConnector._composeKey', function() {
+  it('honours the key', function() {
+    var key1 = composeKey('Car', 'vin');
+    var key2 = composeKey('Car', 'name');
+    expect(key1).to.not.equal(key2);
+  });
+
+  it('honours the model name', function() {
+    var key1 = composeKey('Product', 'name');
+    var key2 = composeKey('Category', 'name');
+    expect(key1).to.not.equal(key2);
+  });
+
+  it('encodes values', function() {
+    // This test is based on the knowledge that we are using ':' separator
+    // when building the composed string
+    var key1 = composeKey('a', 'b:c');
+    var key2 = composeKey('a:b', 'c');
+    expect(key1).to.not.equal(key2);
+  });
+});


### PR DESCRIPTION
Implement KeyValueAccessObject API:

 - set
 - get
 - expire

Connect to strongloop/loopback#2530

This patch requires https://github.com/strongloop/loopback-datasource-juggler/pull/1023 to be back-ported to `juggler@2.x`.

@raymondfeng @ritch @superkhau please review
