### PR TITLE
Fix CI setup

### DIFF
--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -55,6 +55,8 @@ RedisKeyValueConnector.prototype.execute = function(command, args, cb) {
   assert(typeof command === 'string', 'command must be a string');
   assert(typeof cb === 'function', 'callback must be a function');
 
+  command = command.toLowerCase();
+
   debug('EXECUTE %j %j', command, args);
   var cmd = new Redis.Command(command, args, 'utf8', function(err, result) {
     debug('RESULT OF %j -- %j', command, result);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "lib/kv-redis.js",
   "scripts": {
-    "test": "mocha test/unit/*.js && mocha test/integration/*.js",
+    "test": "mocha test/unit/*.js test/integration/*.js",
     "posttest": "npm run lint",
     "lint": "eslint ."
   },

--- a/test/helpers/data-source-factory.js
+++ b/test/helpers/data-source-factory.js
@@ -6,7 +6,7 @@ var extend = require('util')._extend;
 
 var SETTINGS = {
   host: process.env.REDIS_HOST || 'localhost',
-  port: process.env.REDIS_PORT || undefined,
+  port: +process.env.REDIS_PORT || undefined,
   connector: connector,
   // produce nicer stack traces
   showFriendlyErrorStack: true,


### PR DESCRIPTION
This patch is fixing test setup and core implementation to fix CI failures. Note that some tests are still failing because of missing implementation of `ttl()` API, that's out of scope of this change.

cc @superkhau @rmg 