### PR TITLE
Rework test script for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "lib/kv-redis.js",
   "scripts": {
-    "test": "mocha test/unit/*.js test/integration/*.js",
+    "test": "mocha test/unit test/integration",
     "posttest": "npm run lint",
     "lint": "eslint ."
   },

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--recursive


### PR DESCRIPTION
Looks like our CI is not able to pick a list of files passed to `mocha`.

In this commit, we are adding `--recursive` option for mocha, so that CI loads all files in test directories (including helper files, but oh well).

cc @superkhau @rmg 