### PR TITLE
Remove node 10 and 12 support on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
 services:


### PR DESCRIPTION
### Description

Remove support for node 10 and 12 on travis.

connected to https://github.com/strongloop-internal/scrum-apex/issues/184