### PR TITLE
Update dependencies to latest versions, drop Node.js 6, add Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
 services:
     - redis-server

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "debug": "^3.1.0",
-    "ioredis": "^3.2.2",
+    "debug": "^4.1.1",
+    "ioredis": "^4.9.3",
     "loopback-connector": "^4.0.0",
     "strong-globalize": "^4.1.0"
   },
@@ -34,13 +34,13 @@
     "bluebird": "^3.4.1",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "eslint": "^4.19.1",
+    "eslint": "^5.16.0",
     "eslint-config-loopback": "^10.0.0",
     "juggler-v3": "file:./deps/juggler-v3",
     "juggler-v4": "file:./deps/juggler-v4",
-    "loopback-datasource-juggler": "^3.0.0",
-    "mocha": "^5.2.0",
-    "should": "^8.4.0"
+    "loopback-datasource-juggler": "^4.0.0",
+    "mocha": "^6.1.4",
+    "should": "^13.2.3"
   },
   "author": "IBM Corp."
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "The official Redis KeyValue connector for LoopBack",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
- Add Node.js 12 to CI build matrix
- Drop Node.js 6 from supported platforms
- Update dependencies to latest versions