### PR TITLE
EX/PX options

### DIFF
--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -157,7 +157,17 @@ function(modelName, key, value, options, callback) {
         args.push('PX');
         args.push(options.ttl);
       }
-
+	  
+	  if (options.EX) {
+        args.push('EX');
+        args.push(options.EX);
+      }
+	  
+	  if (options.PX) {
+        args.push('PX');
+        args.push(options.PX);
+      }
+	        
       self.execute('SET', args, callback);
     });
   });


### PR DESCRIPTION
set options:  EX / PX 

### Description
You can use 2 options on set: EX and PX.

example: await this.redisRepo.set(token, sessiondatatype, {'EX': 5000});

https://redis.io/commands/set

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
