### PR TITLE
Fix connect error handling

### DIFF
--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -42,7 +42,11 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 
   dataSource.connector._client
-    .once('connect', function() { callback(); })
+    .once('connect', function() {
+      // Remove the error callback
+      dataSource.connector._client.removeListener('error', callback);
+      callback();
+    })
     .once('error', callback);
 };
 


### PR DESCRIPTION
### Description

Without this PR, the connector crashes when Redis is stopped as it makes a callback to the `connect` with the error.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
