### PR TITLE
Exclude 'deps' and '.github' from npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "posttest": "npm run lint",
     "lint": "eslint ."
   },
+  "files": [
+    "intl",
+    "lib",
+    "docs.json"
+  ],
   "license": "MIT",
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION

Related to: https://github.com/strongloop/loopback-connector-mssql/issues/222 

Using similar fix applied to loopback-connector-mssql : https://github.com/strongloop/loopback-connector-mssql/pull/226 


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-kv-redis) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
