### PR TITLE
Allow 4 argument invocation of `execute` to match loopback-datasource-jugglers definition

### DIFF
--- a/lib/kv-redis.js
+++ b/lib/kv-redis.js
@@ -97,14 +97,19 @@ RedisKeyValueConnector.prototype.ping = function(cb) {
  *
  * @param {String} command The Redis command to execute.
  * @param {Array} args List of options for the given command.
- * @callback {Function} callback
+ * @options {Object} options (optional) This is currently not used but included
+ * to match the signature in the loopback-datasource-juggler
+ * @callback {Function} cb Callback invoked on redis command
  * @param {Error} err Error object.
  * @param {*} result The result of the command execution.
  *
- * @header RedisKeyValueConnector.prototype.execute(command, args, cb)
+ * @header RedisKeyValueConnector.prototype.execute(command, args, options, cb)
  */
-RedisKeyValueConnector.prototype.execute = function(command, args, cb) {
-  if (cb === undefined && typeof args === 'function') {
+RedisKeyValueConnector.prototype.execute =
+function(command, args, options, cb) {
+  if (cb === undefined && typeof options === 'function') {
+    cb = options;
+  } else if (cb === undefined && typeof args === 'function') {
     cb = args;
     args = [];
   }

--- a/test/integration/execute.integration.js
+++ b/test/integration/execute.integration.js
@@ -31,5 +31,11 @@ describe('execute', function() {
         done();
       });
     });
-});
 
+  it('accepts 4 arguments to support DataSource.prototype.execute',
+    async function() {
+      const ds = createDataSource();
+      const result = await ds.execute('INFO', ['keyspace'], {});
+      expect(result).to.be.instanceOf(Buffer);
+    });
+});


### PR DESCRIPTION
The loopback-datasource-juggler calls `execute` on the connector with 4 arguments 

```javascript
this.connector.execute(command, args, options, onExecuted)
```

https://github.com/strongloop/loopback-datasource-juggler/blob/8d1690e9b2c76e3d0a8336b47f133e0605cbcc9a/lib/datasource.js#L2720

Since the definition of execute in the kv-redis connector only defines 3 arguments the callback is never assigned or defined which causes the assertion to fail

```
assert(typeof cb === 'function', 'callback must be a function');
```

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
